### PR TITLE
Fixed package.json reading for showing app name

### DIFF
--- a/lib/App.js
+++ b/lib/App.js
@@ -324,7 +324,7 @@ module.exports = Class.extend({
     var httpsPort = app.config.httpsPort;
     var appName = '';
 
-    var json = app.requireJson('package');
+    var json = app.requireJson(app.config.dir + '/package.json');
     if (json.name) {
       appName += json.name;
     }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "express",
     "alternative"
   ],
-  "version": "0.1.58",
+  "version": "0.1.59",
   "main": "lighter.js",
   "bin": {
     "lighter": "commands/cli.js"


### PR DESCRIPTION
When the server starts, the app name is supposed to be displayed next to the ASCII art, but it was broken by a recent change to the requireJson function.  This fixes that issue.
