### PR TITLE
Made response.error more generalized

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -1,8 +1,11 @@
 var http = require('http');
 var zlib = require('zlib');
 
-http.ServerResponse.prototype.view =
-http.ServerResponse.prototype.render = function (name, context) {
+var res = http.ServerResponse.prototype;
+var codes = http.STATUS_CODES;
+
+res.view =
+res.render = function (name, context) {
   var res = this;
   var req = res.request;
   var app = res.app;
@@ -36,40 +39,43 @@ http.ServerResponse.prototype.render = function (name, context) {
         res.zip(html);
       }
       catch (e) {
-        res.error500('Failed while rendering view.');
-        app.logger.error('Failed while rendering view: ' + name);
-        app.logger.error(e);
+        res.error('Failed while rendering view.');
       }
     }
     else {
-      res.error500('View not found.');
-      app.logger.error('View not found: ' + name);
+      res.error('View not found.');
     }
   }
 };
 
-http.ServerResponse.prototype.error404 = function () {
-  var res = this;
-  var app = res.app;
-  res.statusCode = 404;
-  res.setHeader('content-type', 'text/html');
-  if (app.views.error404) {
-    res.render('error404');
-  }
-  else {
-    res.end('<h1>Page Not Found</h1>');
-  }
+res.error404 = function () {
+  this.error(404);
 };
 
-http.ServerResponse.prototype.error500 = function (err) {
+res.error500 =
+res.error = function (err) {
   var res = this;
   var app = res.app;
-  res.statusCode = 500;
+  var num = err;
+  var msg = codes[num];
+  if (!msg) {
+    num = 500;
+    msg = codes[num];
+  }
+  if (typeof err == 'string') {
+    msg = err;
+    err = new Error(msg);
+  }
+  if (err instanceof Error) {
+    app.logger.error(err);
+  }
+  res.statusCode = num;
   res.setHeader('content-type', 'text/html');
-  if (app.views.error500) {
-    res.render('error500', {err: err});
+  var key = 'error' + num;
+  if (app.views[key]) {
+    res.render(key, {error: err});
   }
   else {
-    res.end('<h1>Server Error</h1>' + (err ? err : ''));
+    res.end('<h1>' + msg + '</h1>');
   }
 };

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "express",
     "alternative"
   ],
-  "version": "0.1.65",
+  "version": "0.1.66",
   "main": "lighter.js",
   "bin": {
     "lighter": "commands/cli.js"


### PR DESCRIPTION
The prototype for an HTTP response error can now be used for any standard HTTP status code, but when it takes an error object, defaults to 500.
