### PR TITLE
Read PORT from the environment

### DIFF
--- a/lib/App.js
+++ b/lib/App.js
@@ -56,7 +56,7 @@ module.exports = Class.extend({
       logsDir: 'logs',
       server: null,
       hostName: ipv4() || '127.0.0.1',
-      httpPort: 8888,
+      httpPort: process.env.PORT || 8888,
       decorateContext: null,
       orm: require('ormy'),
       dbs: {},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lighter",
-  "version": "0.1.70",
+  "version": "0.1.71",
   "description": "A lightweight Node.js framework",
   "dependencies": {
     "beams": "^0.0.16",


### PR DESCRIPTION
Port 8888 is the default HTTP port for Lighter, but people should be able to run, for example:

``` bash
PORT=8080 node app
```
